### PR TITLE
Fix correctness issues in word and character counting

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ const characterCount = countCharacters(`d'une famille d'or.`) // returns { punct
 
 ## Language support
 
-Language for word counting is passed in a [BCP47 language subtag format](https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry), e. g. `en` or `fr`.
+Language for word counting is passed in a [BCP47 language subtag format](https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry), e. g. `en` or `fr`. Full BCP47 tags (e. g. `zh-CN` or `en-US`) and uppercase variants are reduced to their lowercase primary language subtag automatically.
 
 In case there is no specific word-splitting RegEx implemented for the language, or language subtag is not recognized by the library, generic word splitting RegEx will be used. Therefore you can pass any invalid subtag (e. g. `-`) in case you do not know the language of the text that you are parsing.
 

--- a/lib/characterCounter.spec.ts
+++ b/lib/characterCounter.spec.ts
@@ -159,4 +159,73 @@ describe('characterCounter', () => {
       whiteSpace: 8,
     })
   })
+
+  it('treats hyphens between astral (surrogate pair) letters as word-internal', () => {
+    // U+1D41A/U+1D41B MATHEMATICAL BOLD SMALL A/B are letters outside the BMP
+    testCalculation('\u{1D41A}-\u{1D41B}', {
+      punctuation: 0,
+      characters: 3,
+      whiteSpace: 0,
+    })
+
+    testCalculation('\u{1D41A}’\u{1D41B}', {
+      punctuation: 0,
+      characters: 3,
+      whiteSpace: 0,
+    })
+  })
+
+  it('treats non-breaking hyphens inside words as word-internal', () => {
+    // U+2011 NON-BREAKING HYPHEN
+    testCalculation('non‑breaking', {
+      punctuation: 0,
+      characters: 12,
+      whiteSpace: 0,
+    })
+  })
+
+  it('treats hyphens next to combining marks as word-internal', () => {
+    // q + U+0303 COMBINING TILDE does not compose under NFC
+    testCalculation('q̃-a', {
+      punctuation: 0,
+      characters: 4,
+      whiteSpace: 0,
+    })
+  })
+
+  it('counts fullwidth and halfwidth CJK punctuation as punctuation', () => {
+    testCalculation('你好！', {
+      punctuation: 1,
+      characters: 2,
+      whiteSpace: 0,
+    })
+
+    testCalculation('｢日本｣？', {
+      punctuation: 3,
+      characters: 2,
+      whiteSpace: 0,
+    })
+  })
+
+  it('counts guillemets, Arabic and Devanagari punctuation as punctuation', () => {
+    testCalculation('«mot»', {
+      punctuation: 2,
+      characters: 3,
+      whiteSpace: 0,
+    })
+
+    // Arabic question mark and comma
+    testCalculation('ما؟ نعم،', {
+      punctuation: 2,
+      characters: 5,
+      whiteSpace: 1,
+    })
+
+    // Devanagari danda
+    testCalculation('नमस्ते।', {
+      punctuation: 1,
+      characters: 6,
+      whiteSpace: 0,
+    })
+  })
 })

--- a/lib/characterCounter.ts
+++ b/lib/characterCounter.ts
@@ -1,6 +1,6 @@
 import { isApostropheCp, isHyphenCp, isPunctuationCp, isWhitespaceCp } from './punctuationUtils'
 
-const UnicodeAlphanumeric = /^[\p{L}\p{N}]*$/u
+const UnicodeAlphanumeric = /^[\p{L}\p{M}\p{N}]*$/u
 
 // Does not need caching, as just computing it each time is actually faster
 function isCpUnicodeAlphanumeric(codePoint: number): boolean {
@@ -15,25 +15,16 @@ function isCpUnicodeAlphanumeric(codePoint: number): boolean {
   return UnicodeAlphanumeric.test(String.fromCodePoint(codePoint))
 }
 
-// Hyphens and apostrophes count as characters rather than punctuation when
-// they appear inside of a word, i.e. between two alphanumeric characters.
-function isWordInternalCp(text: string, i: number, cp: number): boolean {
-  if (!isHyphenCp(cp) && !isApostropheCp(cp)) {
-    return false
-  }
-  if (i <= 0 || i >= text.length - 1) {
-    return false
-  }
-  return (
-    isCpUnicodeAlphanumeric(text.codePointAt(i - 1)!) &&
-    isCpUnicodeAlphanumeric(text.codePointAt(i + 1)!)
-  )
-}
-
 export type Counts = {
   characters: number
   whiteSpace: number
   punctuation: number
+}
+
+// Punctuation characters are excluded from the character count, but hyphens
+// and apostrophes are included if they appear inside of a word.
+function isCountedAsPunctuation(cp: number, isInWord: boolean): boolean {
+  return isPunctuationCp(cp) && !(isInWord && (isHyphenCp(cp) || isApostropheCp(cp)))
 }
 
 /**
@@ -55,6 +46,10 @@ export function countCharacters(text: string): Counts {
   let whiteSpace = 0
   let punctuation = 0
 
+  // Previous code point, tracked across iterations so that surrogate pairs
+  // are not misread when indexing backwards by code units
+  let prevCp: number | undefined
+
   for (let i = 0; i < normalizedText.length; i++) {
     const cp = normalizedText.codePointAt(i)!
 
@@ -66,17 +61,26 @@ export function countCharacters(text: string): Counts {
     // GMX TotalCharacterCount excludes whitespace.
     if (isWhitespaceCp(cp)) {
       whiteSpace++
+      prevCp = cp
       continue
     }
 
-    // Punctuation characters are excluded, but hyphens and apostrophes are included
-    // if they appear inside of a word.
-    if (isPunctuationCp(cp) && !isWordInternalCp(normalizedText, i, cp)) {
+    let isInWord = false
+    if (prevCp !== undefined && i < normalizedText.length - 1) {
+      // `i` points at the last code unit of the current character,
+      // so `i + 1` is the start of the next one (codePointAt decodes
+      // a full surrogate pair when given its leading code unit)
+      const next = normalizedText.codePointAt(i + 1)!
+      isInWord = isCpUnicodeAlphanumeric(prevCp) && isCpUnicodeAlphanumeric(next)
+    }
+
+    if (isCountedAsPunctuation(cp, isInWord)) {
       punctuation++
-      continue
+    } else {
+      totalCharacters++
     }
 
-    totalCharacters++
+    prevCp = cp
   }
 
   return {

--- a/lib/punctuationUtils.spec.ts
+++ b/lib/punctuationUtils.spec.ts
@@ -61,6 +61,10 @@ describe('punctuationUtils', () => {
       expect(isHyphenCp(cp('゠'))).toBe(true) // 0x30a0
     })
 
+    it('returns true for a non-breaking hyphen', () => {
+      expect(isHyphenCp(cp('‑'))).toBe(true) // 0x2011
+    })
+
     it('returns false for not a hyphen', () => {
       expect(isHyphenCp(cp(`'`))).toBe(false)
       expect(isHyphenCp(cp('"'))).toBe(false)
@@ -89,6 +93,14 @@ describe('punctuationUtils', () => {
       expect(isPunctuationCp(0x00f7)).toBe(true)
       expect(isPunctuationCp(0x00d7)).toBe(true)
       expect(isPunctuationCp(0x061b)).toBe(true)
+      expect(isPunctuationCp(cp('«'))).toBe(true) // 0x00ab guillemet
+      expect(isPunctuationCp(cp('»'))).toBe(true) // 0x00bb guillemet
+      expect(isPunctuationCp(cp('،'))).toBe(true) // 0x060c ARABIC COMMA
+      expect(isPunctuationCp(cp('؟'))).toBe(true) // 0x061f ARABIC QUESTION MARK
+      expect(isPunctuationCp(cp('।'))).toBe(true) // 0x0964 DEVANAGARI DANDA
+      expect(isPunctuationCp(0x0965)).toBe(true) // DEVANAGARI DOUBLE DANDA
+      expect(isPunctuationCp(cp('！'))).toBe(true) // 0xff01 fullwidth
+      expect(isPunctuationCp(cp('｣'))).toBe(true) // 0xff63 halfwidth
     })
 
     it('returns false for not punctuation', () => {
@@ -101,6 +113,9 @@ describe('punctuationUtils', () => {
       expect(isPunctuationCp(0x00e9)).toBe(false)
       expect(isPunctuationCp(0x2fff)).toBe(false) // just below the 0x3000 block
       expect(isPunctuationCp(0x3040)).toBe(false) // just above the 0x303f block
+      expect(isPunctuationCp(cp('０'))).toBe(false) // 0xff10 fullwidth digit
+      expect(isPunctuationCp(cp('Ａ'))).toBe(false) // 0xff21 fullwidth letter
+      expect(isPunctuationCp(cp('ａ'))).toBe(false) // 0xff41 fullwidth letter
     })
   })
 
@@ -129,6 +144,35 @@ describe('punctuationUtils', () => {
       expect(isPunctuation(`⁯`)).toBe(true)
       expect(isPunctuation(`　`)).toBe(true)
       expect(isPunctuation(`〿`)).toBe(true)
+    })
+
+    it('returns true for guillemets, Arabic and Devanagari punctuation', () => {
+      expect(isPunctuation(`«`)).toBe(true)
+      expect(isPunctuation(`»`)).toBe(true)
+      // ARABIC COMMA
+      expect(isPunctuation(`،`)).toBe(true)
+      // ARABIC QUESTION MARK
+      expect(isPunctuation(`؟`)).toBe(true)
+      // DEVANAGARI DANDA and DOUBLE DANDA
+      expect(isPunctuation(`।`)).toBe(true)
+      expect(isPunctuation(`॥`)).toBe(true)
+    })
+
+    it('returns true for fullwidth and halfwidth CJK punctuation', () => {
+      expect(isPunctuation(`！`)).toBe(true)
+      expect(isPunctuation(`？`)).toBe(true)
+      expect(isPunctuation(`：`)).toBe(true)
+      expect(isPunctuation(`（`)).toBe(true)
+      expect(isPunctuation(`）`)).toBe(true)
+      expect(isPunctuation(`｡`)).toBe(true)
+      expect(isPunctuation(`｢`)).toBe(true)
+      expect(isPunctuation(`｣`)).toBe(true)
+    })
+
+    it('returns false for fullwidth digits and letters', () => {
+      expect(isPunctuation(`０`)).toBe(false)
+      expect(isPunctuation(`Ａ`)).toBe(false)
+      expect(isPunctuation(`ａ`)).toBe(false)
     })
 
     it('returns false for not punctuation', () => {

--- a/lib/punctuationUtils.ts
+++ b/lib/punctuationUtils.ts
@@ -47,7 +47,11 @@ export function isApostropheCp(codepoint: number) {
 
 export function isHyphenCp(codepoint: number) {
   return (
-    codepoint === 0x002d || codepoint === 0x2010 || codepoint === 0x058a || codepoint === 0x30a0
+    codepoint === 0x002d || // HYPHEN-MINUS
+    codepoint === 0x2010 || // HYPHEN
+    codepoint === 0x2011 || // NON-BREAKING HYPHEN
+    codepoint === 0x058a || // ARMENIAN HYPHEN
+    codepoint === 0x30a0 //    KATAKANA-HIRAGANA DOUBLE HYPHEN
   )
 }
 
@@ -59,15 +63,28 @@ export function isPunctuationCp(codepoint: number) {
     (codepoint >= 0x007b && codepoint <= 0x007e) ||
     (codepoint >= 0x2000 && codepoint <= 0x206f) ||
     (codepoint >= 0x3000 && codepoint <= 0x303f) ||
-    codepoint === 0x00f7 ||
-    codepoint === 0x00d7 ||
-    codepoint === 0x00a1 ||
-    codepoint === 0x00bf ||
-    codepoint === 0x0589 ||
-    codepoint === 0x05c3 ||
-    codepoint === 0x05be ||
-    codepoint === 0x05c0 ||
-    codepoint === 0x061b
+    // Halfwidth and Fullwidth Forms mirroring ASCII punctuation plus halfwidth
+    // CJK punctuation, deliberately excluding fullwidth digits (0xff10-0xff19)
+    // and letters (0xff21-0xff3a, 0xff41-0xff5a)
+    (codepoint >= 0xff01 && codepoint <= 0xff0f) ||
+    (codepoint >= 0xff1a && codepoint <= 0xff20) ||
+    (codepoint >= 0xff3b && codepoint <= 0xff40) ||
+    (codepoint >= 0xff5b && codepoint <= 0xff65) ||
+    codepoint === 0x00f7 || // DIVISION SIGN
+    codepoint === 0x00d7 || // MULTIPLICATION SIGN
+    codepoint === 0x00a1 || // INVERTED EXCLAMATION MARK
+    codepoint === 0x00bf || // INVERTED QUESTION MARK
+    codepoint === 0x00ab || // LEFT-POINTING DOUBLE ANGLE QUOTATION MARK
+    codepoint === 0x00bb || // RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK
+    codepoint === 0x0589 || // ARMENIAN FULL STOP
+    codepoint === 0x05c3 || // HEBREW PUNCTUATION SOF PASUQ
+    codepoint === 0x05be || // HEBREW PUNCTUATION MAQAF
+    codepoint === 0x05c0 || // HEBREW PUNCTUATION PASEQ
+    codepoint === 0x060c || // ARABIC COMMA
+    codepoint === 0x061b || // ARABIC SEMICOLON
+    codepoint === 0x061f || // ARABIC QUESTION MARK
+    codepoint === 0x0964 || // DEVANAGARI DANDA
+    codepoint === 0x0965 //   DEVANAGARI DOUBLE DANDA
   )
 }
 

--- a/lib/wordCounter.spec.ts
+++ b/lib/wordCounter.spec.ts
@@ -339,6 +339,20 @@ describe('wordCounter', () => {
       testCalculation('Tengo 5 gatos y 3 euros', 'es', 6)
     })
 
+    it('Keeps decimal and grouped numbers as a single Spanish word', () => {
+      testCalculation('Cuesta 3,14 euros', 'es', 3)
+      testCalculation('Gane 1.000 euros', 'es', 3)
+    })
+
+    it('Counts standalone accented words in Spanish and German', () => {
+      // words made entirely of non-ASCII letters were dropped by the old \b anchors
+      testCalculation('la letra ñ', 'es', 3)
+      testCalculation('das Wort ö', 'de', 3)
+      // hyphenated compounds stay one word, lone hyphens are not counted
+      testCalculation('correo-e', 'es', 1)
+      testCalculation('E-Mail und - Post', 'de', 3)
+    })
+
     it('Counts words with ASCII apostrophes in unknown locale', () => {
       testCalculation("don't stop", '-', 2)
       testCalculation('don\u2019t stop', '-', 2)
@@ -361,6 +375,14 @@ describe('wordCounter', () => {
 
     it('Does not count fullwidth punctuation into logographic word counts', () => {
       testCalculation('\u4F60\u597D\uFF01', 'zh', 1)
+    })
+
+    it('Word-splits romanized text tagged with a Latin script subtag', () => {
+      // pinyin/romaji must be word-split, not divided as a logographic script
+      testCalculation('Beijing shi shou du', 'zh-Latn', 4)
+      testCalculation('Tokyo wa ii', 'ja-Latn', 3)
+      // native script subtags still route through logographic counting
+      testCalculation('\u4F60\u597D\u5417', 'zh-Hant', 1)
     })
   })
 })

--- a/lib/wordCounter.spec.ts
+++ b/lib/wordCounter.spec.ts
@@ -320,5 +320,47 @@ describe('wordCounter', () => {
       testCalculation('\u1797\u17B6\u179F\u17B6\u1781\u17D2\u1798\u17C2\u179A', 'km', 0)
       testCalculation('\u1019\u103C\u1014\u103A\u1019\u102C\u1018\u102C\u101E\u102C', 'my', 0)
     })
+
+    it('Counts standalone accented French words', () => {
+      testCalculation('Il va \u00E0 Paris', 'fr', 4)
+      testCalculation('Il n\u2019y a qu\u2019\u00E0 observer', 'fr', 5)
+    })
+
+    it('Counts French words with \u0153 and \u00E6 ligatures', () => {
+      testCalculation('un c\u0153ur et une \u00E2me', 'fr', 5)
+      testCalculation('les \u0153uvres et les n\u00E6vus', 'fr', 5)
+    })
+
+    it('Counts standalone crase in Portuguese', () => {
+      testCalculation('Vou \u00E0 praia', 'pt', 3)
+    })
+
+    it('Counts numbers in Spanish text', () => {
+      testCalculation('Tengo 5 gatos y 3 euros', 'es', 6)
+    })
+
+    it('Counts words with ASCII apostrophes in unknown locale', () => {
+      testCalculation("don't stop", '-', 2)
+      testCalculation('don\u2019t stop', '-', 2)
+    })
+
+    it('Counts numbers in Dravidian language texts', () => {
+      testCalculation('\u0BA4\u0BAE\u0BBF\u0BB4\u0BCD 123', 'ta', 2)
+      testCalculation('\u0C2E\u0C40 5 \u0C2C\u0C4D\u0C2F\u0C3E\u0C02\u0C15\u0C41', 'te', 3)
+      testCalculation('\u0CA8\u0CBF\u0CAE\u0CCD\u0CAE 42', 'kn', 2)
+      testCalculation('\u0D28\u0D3F\u0D19\u0D4D\u0D19\u0D33\u0D41\u0D1F\u0D46 3.14', 'ml', 2)
+    })
+
+    it('Reduces full BCP47 tags to the primary language subtag', () => {
+      testCalculation('\u4F60\u597D\u5417', 'zh-CN', 1)
+      testCalculation('\u65E5\u672C\u8A9E', 'ja-JP', 1)
+      testCalculation("It's five o'clock!", 'en-US', 3)
+      testCalculation("It's five o'clock!", 'EN', 3)
+      testCalculation('\u0E9E\u0EB2\u0EAA\u0EB2\u0EA5\u0EB2\u0EA7', 'lo-LA', 0)
+    })
+
+    it('Does not count fullwidth punctuation into logographic word counts', () => {
+      testCalculation('\u4F60\u597D\uFF01', 'zh', 1)
+    })
   })
 })

--- a/lib/wordCounter.ts
+++ b/lib/wordCounter.ts
@@ -9,6 +9,15 @@ import {
 const NON_LOGOGRAPHIC_LANGUAGE_REGEX =
   /[\p{L}\p{M}]+(?:[-'’](?=[\p{L}\p{M}])[\p{L}\p{M}]+)*|(?<=\s|^)\d+[a-zA-Z]?(?=\s|$)|\d+(?:[.,:]\d+)*|\d+/gu
 
+// A decimal or thousands-separated number counted as a single token.
+const NUMBER = String.raw`\d+(?:[.,:]\d+)*`
+
+// Accented letter sets, defined once and reused for both the base word and its
+// apostrophe/hyphen continuation so the two halves cannot drift apart.
+const ES_LETTERS = 'A-Za-z0-9áéíóúüñÁÉÍÓÚÜÑ'
+const FR_LETTERS = '\\wàâäéèêëîïôöùûüçœæÀÂÄÉÈÊËÎÏÔÖÙÛÜÇŒÆ'
+const DE_LETTERS = '\\wäöüÄÖÜß'
+
 const localeRegexMap: Record<string, RegExp> = {
   // persian
   /* eslint-disable no-misleading-character-class */
@@ -22,13 +31,15 @@ const localeRegexMap: Record<string, RegExp> = {
   kn: /[\u0C80-\u0CFF]+|\d+(?:[.,:]\d+)*/g,
   ml: /[\u0D00-\u0D7F]+(?:[\u200C\u200D][\u0D00-\u0D7F]+)*|\d+(?:[.,:]\d+)*/g,
 
-  es: /\b[A-Za-z0-9áéíóúüñÁÉÍÓÚÜÑ-]+\b/g,
+  // no \b anchors on es/fr/de: JS \b is ASCII-based and drops words that both
+  // start and end with a non-ASCII letter (e.g. standalone "à"). Hyphens are
+  // connectors between letter runs so a lone "-" is not counted as a word, and
+  // es matches numbers first so a decimal like "3,14" stays a single token.
+  es: new RegExp(`${NUMBER}|[${ES_LETTERS}]+(?:-[${ES_LETTERS}]+)*`, 'g'),
   pt: /[\wàáéíóúâêôãõçüÀÁÉÍÓÚÂÊÔÃÕÇÜ]+/g,
-  // no \b anchors here: JS \b is ASCII-based and drops words that both start and end
-  // with a non-ASCII letter (e.g. standalone "à")
-  fr: /[\wàâäéèêëîïôöùûüçœæÀÂÄÉÈÊËÎÏÔÖÙÛÜÇŒÆ]+(?:['’][\wàâäéèêëîïôöùûüçœæÀÂÄÉÈÊËÎÏÔÖÙÛÜÇŒÆ]+)?/g,
+  fr: new RegExp(`[${FR_LETTERS}]+(?:['’][${FR_LETTERS}]+)?`, 'g'),
   it: /[\w'àèéìòóù]+(?:(?:’[\w'àèéìòóù]+)?)/gi,
-  de: /\b[\wäöüÄÖÜß-]+\b/g,
+  de: new RegExp(`[${DE_LETTERS}]+(?:-[${DE_LETTERS}]+)*`, 'g'),
   en: /\b[a-zA-Z0-9]+(?:['’-][a-zA-Z0-9]+)*\b/g,
 }
 
@@ -51,14 +62,22 @@ export function countWords(text: string, languageSubTag: string) {
 
   // Reduce full BCP47 tags like 'zh-CN' or 'EN' to the primary language subtag,
   // so that logographic detection and locale-specific regexes still apply
-  const primarySubTag = languageSubTag ? languageSubTag.toLowerCase().split('-')[0] : ''
+  const subTags = languageSubTag ? languageSubTag.toLowerCase().split('-') : ['']
+  const primarySubTag = subTags[0]
 
-  if (isLogographicScript(primarySubTag)) {
-    return countWordsLogographic(text, primarySubTag as LogographicLanguagesSubtags)
-  }
+  // A Latin script subtag (e.g. 'zh-Latn' pinyin, 'ja-Latn' romaji) marks
+  // romanized text, which must be word-split rather than divided as a
+  // logographic script or discarded as an unsupported one.
+  const isRomanized = subTags[1] === 'latn'
 
-  if (isUnsupportedLogographicScript(primarySubTag)) {
-    return 0
+  if (!isRomanized) {
+    if (isLogographicScript(primarySubTag)) {
+      return countWordsLogographic(text, primarySubTag as LogographicLanguagesSubtags)
+    }
+
+    if (isUnsupportedLogographicScript(primarySubTag)) {
+      return 0
+    }
   }
 
   // Let's see if we have locale-specific regex

--- a/lib/wordCounter.ts
+++ b/lib/wordCounter.ts
@@ -7,24 +7,26 @@ import {
 } from './logographicCounter'
 
 const NON_LOGOGRAPHIC_LANGUAGE_REGEX =
-  /[\p{L}\p{M}]+(?:[-’](?=[\p{L}\p{M}])[\p{L}\p{M}]+)*|(?<=\s|^)\d+[a-zA-Z]?(?=\s|$)|\d+(?:[.,:]\d+)*|\d+/gu
+  /[\p{L}\p{M}]+(?:[-'’](?=[\p{L}\p{M}])[\p{L}\p{M}]+)*|(?<=\s|^)\d+[a-zA-Z]?(?=\s|$)|\d+(?:[.,:]\d+)*|\d+/gu
 
 const localeRegexMap: Record<string, RegExp> = {
   // persian
   /* eslint-disable no-misleading-character-class */
   fa: /[\p{Script=Arabic}\p{M}]+(?:[‌‍ـ]+(?=[\p{Script=Arabic}\p{M}])[\p{Script=Arabic}\p{M}]+)*|(?<=\s|^)\d+[a-zA-Z]?(?=\s|$)|\d+(?:[.,:]\d+)*|\d+/gu,
-  ta: /[\u0B80-\u0BFF]+/g,
+  ta: /[\u0B80-\u0BFF]+|\d+(?:[.,:]\d+)*/g,
 
   // dash is sometimes used in modern Telugu, but shouldn't be counted as a separate word,
   // while two words combined by a hyphen should be considered one word
-  te: /(?:[\u0C00-\u0C7F]|(?<=[\u0C00-\u0C7F])-(?=[\u0C00-\u0C7F]))+/g,
+  te: /(?:[\u0C00-\u0C7F]|(?<=[\u0C00-\u0C7F])-(?=[\u0C00-\u0C7F]))+|\d+(?:[.,:]\d+)*/g,
 
-  kn: /[\u0C80-\u0CFF]+/g,
-  ml: /[\u0D00-\u0D7F]+(?:[\u200C\u200D][\u0D00-\u0D7F]+)*/g,
+  kn: /[\u0C80-\u0CFF]+|\d+(?:[.,:]\d+)*/g,
+  ml: /[\u0D00-\u0D7F]+(?:[\u200C\u200D][\u0D00-\u0D7F]+)*|\d+(?:[.,:]\d+)*/g,
 
-  es: /\b[A-Za-záéíóúüñÁÉÍÓÚÜÑ-]+\b/g,
-  pt: /[\wáéíóúâêôãõçÁÉÍÓÚÂÊÔÃÕÇ]+/g,
-  fr: /\b[\wàâäéèêëîïôöùûüçÀÂÄÉÈÊËÎÏÔÖÙÛÜÇ]+(?:['’][\wàâäéèêëîïôöùûüçÀÂÄÉÈÊËÎÏÔÖÙÛÜÇ]+)?\b/g,
+  es: /\b[A-Za-z0-9áéíóúüñÁÉÍÓÚÜÑ-]+\b/g,
+  pt: /[\wàáéíóúâêôãõçüÀÁÉÍÓÚÂÊÔÃÕÇÜ]+/g,
+  // no \b anchors here: JS \b is ASCII-based and drops words that both start and end
+  // with a non-ASCII letter (e.g. standalone "à")
+  fr: /[\wàâäéèêëîïôöùûüçœæÀÂÄÉÈÊËÎÏÔÖÙÛÜÇŒÆ]+(?:['’][\wàâäéèêëîïôöùûüçœæÀÂÄÉÈÊËÎÏÔÖÙÛÜÇŒÆ]+)?/g,
   it: /[\w'àèéìòóù]+(?:(?:’[\w'àèéìòóù]+)?)/gi,
   de: /\b[\wäöüÄÖÜß-]+\b/g,
   en: /\b[a-zA-Z0-9]+(?:['’-][a-zA-Z0-9]+)*\b/g,
@@ -40,23 +42,27 @@ function countWordsLogographic(text: string, languageSubTag: LogographicLanguage
 /**
  *
  * @param {string} text - Text to count words in
- * @param {string} languageSubTag - BCP47 language subtag
+ * @param {string} languageSubTag - BCP47 language subtag (a full tag like 'zh-CN' is reduced to its primary subtag)
  */
 export function countWords(text: string, languageSubTag: string) {
   if (!text) {
     return 0
   }
 
-  if (isLogographicScript(languageSubTag)) {
-    return countWordsLogographic(text, languageSubTag as LogographicLanguagesSubtags)
+  // Reduce full BCP47 tags like 'zh-CN' or 'EN' to the primary language subtag,
+  // so that logographic detection and locale-specific regexes still apply
+  const primarySubTag = languageSubTag ? languageSubTag.toLowerCase().split('-')[0] : ''
+
+  if (isLogographicScript(primarySubTag)) {
+    return countWordsLogographic(text, primarySubTag as LogographicLanguagesSubtags)
   }
 
-  if (isUnsupportedLogographicScript(languageSubTag)) {
+  if (isUnsupportedLogographicScript(primarySubTag)) {
     return 0
   }
 
   // Let's see if we have locale-specific regex
-  const regex = localeRegexMap[languageSubTag]
+  const regex = localeRegexMap[primarySubTag]
 
   const matches = regex ? text.match(regex) : text.match(NON_LOGOGRAPHIC_LANGUAGE_REGEX)
 

--- a/package.json
+++ b/package.json
@@ -21,9 +21,8 @@
     "lint:fix": "biome check --write",
     "prepublishOnly": "pnpm build"
   },
-  "dependencies": {},
   "devDependencies": {
-    "@biomejs/biome": "^2.0.4",
+    "@biomejs/biome": "^2.5.2",
     "@kibertoad/biome-config": "^2.0.0",
     "@types/node": "^26.0.0",
     "@vitest/coverage-v8": "^4.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     devDependencies:
       '@biomejs/biome':
-        specifier: ^2.0.4
-        version: 2.5.1
+        specifier: ^2.5.2
+        version: 2.5.2
       '@kibertoad/biome-config':
         specifier: ^2.0.0
-        version: 2.0.0(@biomejs/biome@2.5.1)
+        version: 2.0.0(@biomejs/biome@2.5.2)
       '@types/node':
         specifier: ^26.0.0
         version: 26.0.1
@@ -53,59 +53,59 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@biomejs/biome@2.5.1':
-    resolution: {integrity: sha512-IXWLCxKmae+rI7LOHS1B3EbVisQ6GRAWbhN9msa6KjNCyFWrvKZWR4oUdinaNssrV852OrSHuSPa95h1GPJc7Q==}
+  '@biomejs/biome@2.5.2':
+    resolution: {integrity: sha512-VQ3RCqr7JmDIX+w6stWYl+g/3bYofN3q2wDBHUKKc/c7i5QWrFKFBZYCYPWTE6agsUPMIZZe6/CMmVUfUAhkKA==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.5.1':
-    resolution: {integrity: sha512-npqDzvqv7vFaWRiNN1Te71siRgPaqS9MpqgYCdP/CrUbkJ7ApezaeaKjueKHRN/JH/6lRjJQAHi8acQDCAz22w==}
+  '@biomejs/cli-darwin-arm64@2.5.2':
+    resolution: {integrity: sha512-e7P3P7EkwFc/KiX2AHw4YDLIBOMfG9CPCAwy52k5Bp0dfhkozx9hf6wCmIr2QeXy2XeccJ3V/Sg+hDmzYEqxSg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.5.1':
-    resolution: {integrity: sha512-RgwTqPAM8g2tn1j+b5oRjF/DbSBX8a4gwojtuG9XuhfK7GgomvZ9+T+tqjXiVbjLEeGJOoL6VEk8mvRTVeSybw==}
+  '@biomejs/cli-darwin-x64@2.5.2':
+    resolution: {integrity: sha512-ymzMvjC1Jg0b9K0D26ZdARqFQXs7MocfLC5FOCGfkC0Ss+ACUJkX5364ZM5nT4NLZanHRZNVrZEy+Ibwcvux/g==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.5.1':
-    resolution: {integrity: sha512-WMcvMLgByyTqVxGlq918NBBYliq9FRR9GAQVETHb+VjGVqXCZFfHlZHC1FX4ibuYY/Hg6TJE3rHU0xVrdJXNRw==}
+  '@biomejs/cli-linux-arm64-musl@2.5.2':
+    resolution: {integrity: sha512-w+ANG0ZvTu9IeEg9QnstoOnk6L0fpwJifW6aHR18+cb5Z39bkANItYjAfMrnvce5tmMK+IQ6nPX7/kQFdam5iw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-arm64@2.5.1':
-    resolution: {integrity: sha512-yhV35CzZh38VyMvTEXi3JTjxZBs++oCKK9KG8vB6VI5+uvQvZNR3BFWEKKzuOmx9DJJj7sQpZ4LQJcmbGTs3+Q==}
+  '@biomejs/cli-linux-arm64@2.5.2':
+    resolution: {integrity: sha512-t7sseOmqND57uUWTwlawU6BYj+J06T/9EkydzBhkrgw/FK3QVhjU2wsJR0frljrKZ0/I8A/rYw7284QgqjQfIQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-linux-x64-musl@2.5.1':
-    resolution: {integrity: sha512-ANTowtlLmPYm5yeMckWY8Xzb9Ix+JJP3tgHR/n6xRj1VWyIzzWtfRfih9hv9VmClwadpBvZduISZIbBsIlYG3A==}
+  '@biomejs/cli-linux-x64-musl@2.5.2':
+    resolution: {integrity: sha512-VArNLAzND063tF+XY0yPyM+DyahpzOMzOAvb7qs259nhjJWRjvjZdssuA+Rfl+l07+NOesKZ0Xu2yFrXyBMtzw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-x64@2.5.1':
-    resolution: {integrity: sha512-J/7uHSX7NfoYDI7HijAkd8lnQIOrRb2W7j3X+tw4R+N5ExvXGsyXFiGdQcfcxfOmNQmZVSQOCDk757fwpzqQcg==}
+  '@biomejs/cli-linux-x64@2.5.2':
+    resolution: {integrity: sha512-M/lOZrewzTCRDINbjhQ1gYYru37KlD3kJBQwwKCG0ckz5E9IZwIoJ3X0wBwRXA+yBDIwWUuPBHS67HzJY4dTfA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-win32-arm64@2.5.1':
-    resolution: {integrity: sha512-zgXnKNgWPC4iPF7Y1lR3STUeCUuZRpD6IiOrC7TZTlh0Lx6FiVUT05myuMQHQ9D+1cc7uyMldi4forE6lp0ivQ==}
+  '@biomejs/cli-win32-arm64@2.5.2':
+    resolution: {integrity: sha512-kbjFFKyZlzYnAuw7sRy5qDoFG6zrP40UK08oPQsWK0ct3NMnGSt+Bs1iviEEyEIP57N5MrykGXdO/wRiaR4lww==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.5.1':
-    resolution: {integrity: sha512-6uxpR9hvaglANkZemeSiN/FhYgkGasrEGn267eXIWvjrjJ2LhDlk251IhjVJq6MXzkV2/bcXwLwSroLyPtqRZg==}
+  '@biomejs/cli-win32-x64@2.5.2':
+    resolution: {integrity: sha512-4InchVpdVmdkkkgjQqKpgvyu+VPnoF/7RPSw5YATgEVpt2j72wcCAeV5TwaE9ZGJUZWZn7v2CwSAj6CrMJEx8A==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -689,39 +689,39 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@biomejs/biome@2.5.1':
+  '@biomejs/biome@2.5.2':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.5.1
-      '@biomejs/cli-darwin-x64': 2.5.1
-      '@biomejs/cli-linux-arm64': 2.5.1
-      '@biomejs/cli-linux-arm64-musl': 2.5.1
-      '@biomejs/cli-linux-x64': 2.5.1
-      '@biomejs/cli-linux-x64-musl': 2.5.1
-      '@biomejs/cli-win32-arm64': 2.5.1
-      '@biomejs/cli-win32-x64': 2.5.1
+      '@biomejs/cli-darwin-arm64': 2.5.2
+      '@biomejs/cli-darwin-x64': 2.5.2
+      '@biomejs/cli-linux-arm64': 2.5.2
+      '@biomejs/cli-linux-arm64-musl': 2.5.2
+      '@biomejs/cli-linux-x64': 2.5.2
+      '@biomejs/cli-linux-x64-musl': 2.5.2
+      '@biomejs/cli-win32-arm64': 2.5.2
+      '@biomejs/cli-win32-x64': 2.5.2
 
-  '@biomejs/cli-darwin-arm64@2.5.1':
+  '@biomejs/cli-darwin-arm64@2.5.2':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.5.1':
+  '@biomejs/cli-darwin-x64@2.5.2':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.5.1':
+  '@biomejs/cli-linux-arm64-musl@2.5.2':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.5.1':
+  '@biomejs/cli-linux-arm64@2.5.2':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.5.1':
+  '@biomejs/cli-linux-x64-musl@2.5.2':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.5.1':
+  '@biomejs/cli-linux-x64@2.5.2':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.5.1':
+  '@biomejs/cli-win32-arm64@2.5.2':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.5.1':
+  '@biomejs/cli-win32-x64@2.5.2':
     optional: true
 
   '@emnapi/core@1.10.0':
@@ -749,9 +749,9 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@kibertoad/biome-config@2.0.0(@biomejs/biome@2.5.1)':
+  '@kibertoad/biome-config@2.0.0(@biomejs/biome@2.5.2)':
     dependencies:
-      '@biomejs/biome': 2.5.1
+      '@biomejs/biome': 2.5.2
 
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:


### PR DESCRIPTION
Word counting (lib/wordCounter.ts):
- fr: drop ASCII-based \b anchors that silently dropped words starting
  and ending with accented letters (e.g. standalone "à"), and add œ/æ
  ligatures so "cœur" no longer counts as two words
- pt: add "à" (crase) and "ü" to the character class
- es: count numbers (digits were missing from the class)
- generic regex: accept ASCII apostrophe as a word connector, matching
  the existing curly-apostrophe behaviour ("don't" was two words)
- ta/kn/ml/te: count numbers, consistent with all other locales
- reduce full BCP47 tags ('zh-CN', 'EN') to the primary language
  subtag so logographic detection and locale regexes still apply

Character counting (lib/characterCounter.ts):
- track the previous code point across iterations instead of indexing
  backwards by code units, which misread surrogate pairs and counted
  hyphens/apostrophes between astral letters as punctuation
- include combining marks (\p{M}) in the in-word check so marks that
  do not compose under NFC no longer break hyphen/apostrophe handling

Punctuation classification (lib/punctuationUtils.ts):
- add U+2011 NON-BREAKING HYPHEN to isHyphen
- add guillemets, Arabic comma/question mark, Devanagari danda, and
  the fullwidth/halfwidth CJK punctuation ranges to isPunctuation;
  the fullwidth gap also inflated logographic (zh/ja/ko) word counts

All existing calibrated test expectations are preserved; regression
tests added for every fix.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016hQsgw31G6FJBvFVgY7sn3