### PR TITLE
Add OIDC-based npm publishing with provenance

### DIFF
--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -1,0 +1,36 @@
+---
+name: label-check
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+      - unlabeled
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  enforce-release-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require a release label
+        env:
+          LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+        run: |
+          echo "PR labels: $LABELS"
+          case "$LABELS" in
+            *'"patch"'*|*'"minor"'*|*'"major"'*|*'"skip-release"'*)
+              echo "Required release label is set."
+              ;;
+            *)
+              echo "::error::PR must have one of these labels: patch, minor, major, skip-release"
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,83 @@
+---
+name: publish
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    if: github.event.pull_request.merged == true && (contains(github.event.pull_request.labels.*.name, 'patch') || contains(github.event.pull_request.labels.*.name, 'minor') || contains(github.event.pull_request.labels.*.name, 'major'))
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.base.ref }}
+          persist-credentials: false
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24.x
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Install dependencies
+        run: pnpm install --ignore-scripts --frozen-lockfile
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Determine version bump
+        id: version
+        run: |
+          if ${{ contains(github.event.pull_request.labels.*.name, 'major') }}; then
+            echo "bump=major" >> $GITHUB_OUTPUT
+          elif ${{ contains(github.event.pull_request.labels.*.name, 'minor') }}; then
+            echo "bump=minor" >> $GITHUB_OUTPUT
+          else
+            echo "bump=patch" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Bump version
+        id: bump
+        env:
+          VERSION_BUMP: ${{ steps.version.outputs.bump }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          pnpm version "$VERSION_BUMP" -m "chore: release v%s"
+          NEW_VERSION="v$(node -p "require('./package.json').version")"
+          echo "tag=${NEW_VERSION}" >> $GITHUB_OUTPUT
+          REMOTE="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git push "$REMOTE" "HEAD:${BASE_REF}"
+          git push "$REMOTE" --tags
+
+      - name: Publish to npm
+        run: pnpm publish --access public --provenance --no-git-checks
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ steps.bump.outputs.tag }}
+        run: gh release create "$RELEASE_TAG" --title "$RELEASE_TAG" --generate-notes

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.1.1",
   "license": "MIT",
   "description": "Fast, GMX-V compliant word and character counter. Can count both logographic and non-logographic languages correctly. Also supports generic counting for cases when language is unknown.",
+  "author": "Igor Savin <kibertoad@gmail.com>",
   "maintainers": [
     {
       "name": "Igor Savin",
@@ -37,7 +38,10 @@
   "packageManager": "pnpm@10.33.4",
   "repository": {
     "type": "git",
-    "url": "git://github.com/kibertoad/gmx-word-counter.git"
+    "url": "git+https://github.com/kibertoad/gmx-word-counter.git"
+  },
+  "bugs": {
+    "url": "https://github.com/kibertoad/gmx-word-counter/issues"
   },
   "keywords": [
     "gmx",


### PR DESCRIPTION
Adds OIDC-based npm publishing with provenance, mirroring the setup in `toad-cache`.

## What changed
- **`.github/workflows/publish.yml`** — runs when a PR into `main` is merged with a `patch`/`minor`/`major` label. It bumps the version, pushes the tag, publishes to npm with `--provenance`, and cuts a GitHub release. Uses OIDC (`id-token: write`) so no long-lived npm token is needed.
- **`.github/workflows/label-check.yml`** — enforces that every PR carries one of `patch`, `minor`, `major`, or `skip-release`.
- **`package.json`** — provenance metadata: added `author`, added `bugs`, and switched `repository.url` from the deprecated `git://` protocol to `git+https://` so npm can match the source repo.

## Prerequisites for the first release
- Configure npm trusted publishing (OIDC) for `gmx-word-counter` pointing at this repo's `publish` workflow.
- Add the `patch`, `minor`, `major`, and `skip-release` labels to the repo.