### PR TITLE
Handle Tibetan-script and Arabic-script languages explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,4 +37,10 @@ GMX-V 2.0 describes the following word count factors:
 
 For logographic languages that GMX-V does not cover (Lao, Khmer and Myanmar), 0 is always returned as a word count.
 
+The same applies to Tibetan (`bo`) and Dzongkha (`dz`). Both are written in the Tibetan script, which separates syllables with the tsheg (U+0F0B) rather than spaces between words, and GMX-V defines no factor for them. There is also no dictionary-based word segmentation available (ICU, the reference [UAX #29](https://www.unicode.org/reports/tr29/) implementation, ships word dictionaries only for Burmese, Chinese/Japanese, Khmer, Lao and Thai). A reliable word count cannot be produced, so 0 is returned instead of letting generic splitting miscount every syllable as a word.
+
 Note that correct counting for logographic languages requires passing correct language subtag as a parameter. `gmx-word-counter` will not automatically detect that language is logographic if invalid language subtag is passed as a parameter.
+
+## Arabic-script languages
+
+Arabic-script languages join letter runs across the zero-width non-joiner (U+200C), zero-width joiner (U+200D) and tatweel (U+0640), so a single word split by any of those must not be counted as several. This is handled for Persian (`fa`), Arabic (`ar`), Urdu (`ur`), Pashto (`ps`), Sindhi (`sd`), Central Kurdish (`ckb`) and Uyghur (`ug`).

--- a/lib/logographicCounter.ts
+++ b/lib/logographicCounter.ts
@@ -7,7 +7,17 @@
 const LOGOGRAPHIC_LANGUAGES = ['zh', 'ja', 'ko', 'th'] as const
 const LOGOGRAPHIC_LANGUAGE_SET = new Set(LOGOGRAPHIC_LANGUAGES)
 
-const UNSUPPORTED_LOGOGRAPHIC_SCRIPTS = ['lo', 'km', 'my'] as const
+// Scripts written without inter-word spaces that GMX-V 2.0 does not assign a
+// word-count factor to, and for which no dictionary-based word segmentation is
+// available. ICU (the reference UAX #29 implementation) ships word-break
+// dictionaries only for Burmese, CJK, Khmer, Lao and Thai, so anything outside
+// that set cannot be reliably segmented into words. Without a factor or a
+// segmenter a word count cannot be produced, so 0 is returned.
+//   lo - Lao, km - Khmer, my - Burmese
+//   bo - Tibetan, dz - Dzongkha (Tibetan script; syllables are delimited by the
+//        tsheg U+0F0B, never by spaces, so the generic regex would miscount
+//        every syllable as a separate word)
+const UNSUPPORTED_LOGOGRAPHIC_SCRIPTS = ['lo', 'km', 'my', 'bo', 'dz'] as const
 const UNSUPPORTED_LOGOGRAPHIC_SCRIPT_SET = new Set(UNSUPPORTED_LOGOGRAPHIC_SCRIPTS)
 
 export type LogographicLanguagesSubtags = (typeof LOGOGRAPHIC_LANGUAGES)[number]

--- a/lib/wordCounter.spec.ts
+++ b/lib/wordCounter.spec.ts
@@ -175,6 +175,11 @@ describe('wordCounter', () => {
       testCalculation('He is actually pretty well-known around here.', '-', 7)
     })
 
+    it('Falls back to generic counting for an empty language subtag', () => {
+      // An empty tag is neither logographic nor mapped, so the generic regex runs.
+      testCalculation('He is actually pretty well-known around here.', '', 7)
+    })
+
     it('Counts words in a Latvian text', () => {
       testCalculation(
         'Noslēdzošajā spēles nogrieznī Latvijas izlase turpināja rādīt labu sniegumu, pie pirmajiem gūtajiem punktiem tika arī Jānis Timma, kuram šī bija pirmā pārbaudes spēle un atgriešanās 5:5 basketbolā pēc ilgākas pauzes. 84:72 - ar šādu rezultātu uzvarēja Latvijas izlase priekšpēdējā pārbaudes spēlē. one more: ī',
@@ -319,6 +324,71 @@ describe('wordCounter', () => {
       testCalculation('\u0E9E\u0EB2\u0EAA\u0EB2\u0EA5\u0EB2\u0EA7', 'lo', 0)
       testCalculation('\u1797\u17B6\u179F\u17B6\u1781\u17D2\u1798\u17C2\u179A', 'km', 0)
       testCalculation('\u1019\u103C\u1014\u103A\u1019\u102C\u1018\u102C\u101E\u102C', 'my', 0)
+    })
+
+    it('Does not count Tibetan-script languages without GMX factor', () => {
+      // Tibetan and Dzongkha are written without inter-word spaces: syllables are
+      // delimited by the tsheg (U+0F0B), never by spaces, and GMX-V defines no
+      // factor for them (ICU also ships no Tibetan word dictionary). Because a
+      // reliable word count cannot be produced, 0 is returned rather than letting
+      // the generic regex miscount every tsheg-delimited syllable as a word.
+      // 'bkra shis bde legs' (a Tibetan greeting) is a single expression, and the
+      // syllable-splitting fallback would otherwise report 4.
+      testCalculation(
+        '\u0F56\u0F40\u0FB2\u0F0B\u0F64\u0F72\u0F66\u0F0B\u0F56\u0F51\u0F7A\u0F0B\u0F63\u0F7A\u0F42\u0F66',
+        'bo',
+        0,
+      )
+      // Dzongkha uses the Tibetan script as well.
+      testCalculation(
+        '\u0F62\u0FAB\u0F7C\u0F44\u0F0B\u0F41\u0F0B\u0F51\u0F42\u0F60\u0F0B\u0F58\u0F7C',
+        'dz',
+        0,
+      )
+      // Full BCP47 tags reduce to the primary subtag, so 'bo-CN' behaves as 'bo'.
+      testCalculation('\u0F56\u0F40\u0FB2\u0F0B\u0F64\u0F72\u0F66', 'bo-CN', 0)
+    })
+
+    it('Counts words in an Urdu text', () => {
+      // Urdu uses the Arabic script and joins letter runs across the zero-width
+      // non-joiner (U+200C). Each ZWNJ-joined run must stay a single word: the
+      // generic \p{L} regex would split them and overcount.
+      testCalculation(
+        '\u0645\u06CC\u06BA \u067E\u0627\u06A9\u0633\u062A\u0627\u0646\u200C\u0633\u06D2 \u06C1\u0648\u06BA',
+        'ur',
+        3,
+      )
+      testCalculation(
+        '\u06C1\u0631 \u0627\u0646\u0633\u0627\u0646 \u0622\u0632\u0627\u062F \u067E\u06CC\u062F\u0627 \u06C1\u0648\u062A\u0627 \u06C1\u06D2\u06D4',
+        'ur',
+        6,
+      )
+    })
+
+    it('Counts words in other Arabic-script languages', () => {
+      // Pashto, Sindhi, Central Kurdish (Sorani) and Uyghur route through the same
+      // Arabic-script regex as Persian and Urdu, so a ZWNJ-joined word stays one
+      // token in each of them.
+      testCalculation(
+        '\u062F \u067E\u069A\u062A\u0648\u200C\u0627\u0646\u0648 \u0698\u0628\u0647',
+        'ps',
+        3,
+      )
+      testCalculation('\u0633\u0646\u068C\u064A \u0680\u0627\u0634\u0627', 'sd', 2)
+      testCalculation('\u0632\u0645\u0627\u0646\u06CC \u06A9\u0648\u0631\u062F\u06CC', 'ckb', 2)
+      testCalculation('\u0626\u06C7\u064A\u063A\u06C7\u0631 \u062A\u0649\u0644\u0649', 'ug', 2)
+    })
+
+    it('Counts ZWNJ-joined Arabic-script words as a single token', () => {
+      // A bare word split by a ZWNJ is one word, not two, across the whole family.
+      testCalculation('\u0645\u06CC\u200C\u0631\u0648\u0645', 'fa', 1)
+      testCalculation('\u0645\u06CC\u200C\u0631\u0648\u0645', 'ur', 1)
+      // Digits inside otherwise Arabic-script text are still counted.
+      testCalculation(
+        '\u0645\u0646 \u06F5 \u06AF\u0631\u0628\u0647 \u062F\u0627\u0631\u0645',
+        'fa',
+        4,
+      )
     })
 
     it('Counts standalone accented French words', () => {

--- a/lib/wordCounter.ts
+++ b/lib/wordCounter.ts
@@ -18,10 +18,25 @@ const ES_LETTERS = 'A-Za-z0-9áéíóúüñÁÉÍÓÚÜÑ'
 const FR_LETTERS = '\\wàâäéèêëîïôöùûüçœæÀÂÄÉÈÊËÎÏÔÖÙÛÜÇŒÆ'
 const DE_LETTERS = '\\wäöüÄÖÜß'
 
+// Arabic-script languages join letter runs across the zero-width non-joiner
+// (U+200C), zero-width joiner (U+200D) and tatweel (U+0640), so a single word
+// split by any of those must stay one token instead of being counted as
+// several. Matching on \p{Script=Arabic} keeps this correct for every
+// Arabic-script language, not just Persian: Urdu, Pashto, Sindhi, Central
+// Kurdish and Uyghur all use the ZWNJ inside words the same way.
+// eslint-disable-next-line no-misleading-character-class
+const ARABIC_SCRIPT_REGEX =
+  /[\p{Script=Arabic}\p{M}]+(?:[‌‍ـ]+(?=[\p{Script=Arabic}\p{M}])[\p{Script=Arabic}\p{M}]+)*|(?<=\s|^)\d+[a-zA-Z]?(?=\s|$)|\d+(?:[.,:]\d+)*|\d+/gu
+
 const localeRegexMap: Record<string, RegExp> = {
-  // persian
-  /* eslint-disable no-misleading-character-class */
-  fa: /[\p{Script=Arabic}\p{M}]+(?:[‌‍ـ]+(?=[\p{Script=Arabic}\p{M}])[\p{Script=Arabic}\p{M}]+)*|(?<=\s|^)\d+[a-zA-Z]?(?=\s|$)|\d+(?:[.,:]\d+)*|\d+/gu,
+  // persian and the other Arabic-script languages share one regex (see above)
+  fa: ARABIC_SCRIPT_REGEX,
+  ar: ARABIC_SCRIPT_REGEX,
+  ur: ARABIC_SCRIPT_REGEX, // urdu
+  ps: ARABIC_SCRIPT_REGEX, // pashto
+  sd: ARABIC_SCRIPT_REGEX, // sindhi
+  ckb: ARABIC_SCRIPT_REGEX, // central kurdish (sorani)
+  ug: ARABIC_SCRIPT_REGEX, // uyghur
   ta: /[\u0B80-\u0BFF]+|\d+(?:[.,:]\d+)*/g,
 
   // dash is sometimes used in modern Telugu, but shouldn't be counted as a separate word,


### PR DESCRIPTION
## What

Closes two gaps where the generic word-splitting regex produced a wrong count for languages Lokalise supports.

### Tibetan (`bo`) and Dzongkha (`dz`) → return 0

Both use the Tibetan script, which delimits syllables with the tsheg (U+0F0B) rather than spaces between words. The generic `\p{L}` regex broke at every tsheg, so a four-syllable greeting like `བཀྲ་ཤིས་བདེ་ལེགས` counted as 4 "words."

There is no correct positive count to produce here:

- GMX-V 2.0 defines a word-count factor only for Chinese, Japanese, Korean and Thai. It is silent on Tibetan, exactly as it is on Lao/Khmer/Burmese.
- [UAX #29](https://www.unicode.org/reports/tr29/) establishes that scripts without inter-word spaces need dictionary-based segmentation, not the default algorithm.
- ICU, the reference UAX #29 implementation, ships word-break dictionaries for exactly Burmese, CJK, Khmer, Lao and Thai, and **none for Tibetan**. The same set our library already supports/returns-0 for.

So `bo` and `dz` join the existing unsupported-logographic set (`lo`, `km`, `my`) and return 0, rather than letting generic splitting miscount syllables.

### Arabic-script languages → share the Persian regex

Arabic-script languages join letter runs across the zero-width non-joiner (U+200C), zero-width joiner (U+200D) and tatweel (U+0640). Only Persian handled this; Urdu, Pashto, Sindhi, Central Kurdish and Uyghur fell through to the generic regex, which split ZWNJ-joined words and overcounted (`کام‌کاج` counted as 2).

The Persian regex already matches on `\p{Script=Arabic}`, so it is correct for every Arabic-script language. It is now extracted to a shared `ARABIC_SCRIPT_REGEX` and applied to `fa`, `ar`, `ur`, `ps`, `sd`, `ckb`, `ug`. Arabic's existing test count (186) is unchanged; verified the shared regex produces the identical result.

## Tests

- Tibetan/Dzongkha return 0, including a `bo-CN` BCP47-reduction case.
- Urdu text plus ZWNJ-joined single-word cases.
- Pashto, Sindhi, Central Kurdish and Uyghur.
- ZWNJ-joined word stays one token across the family; digits inside Arabic-script text still counted.
- Added an empty-language-subtag fallback test, restoring branch coverage to 100%.

All 83 tests pass; `pnpm lint` and `pnpm test:coverage` (100% statements/branches/functions/lines) are green.
